### PR TITLE
Destination amount refactor

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
-  Max: 6
+  Max: 7
 
 # Offense count: 7
 # Cop supports --auto-correct.

--- a/app/controllers/errors/payment_error.rb
+++ b/app/controllers/errors/payment_error.rb
@@ -1,9 +1,9 @@
 module Errors
   class PaymentError < ApplicationError
-    attr_reader :message, :body
-    def initialize(message, body = nil)
+    attr_reader :message, :transaction
+    def initialize(message, transaction = nil)
       @message = message
-      @body = body
+      @transaction = transaction
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -59,7 +59,6 @@ class Order < ApplicationRecord
         save!
         create_state_history
         block.call if block.present?
-        self
       end
     rescue MicroMachine::InvalidState
       raise Errors::OrderError, "Invalid action on this #{state} order"

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -33,7 +33,7 @@ module OrderService
 
   def self.approve!(order, by: nil)
     transaction = order.approve! do
-      transaction = PaymentService.capture_charge(order.external_charge_id)
+      PaymentService.capture_charge(order.external_charge_id)
     end
     order.transactions << transaction
     PostNotificationJob.perform_later(order.id, Order::APPROVED, by)

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -35,7 +35,7 @@ class OrderSubmitService
   rescue Errors::PaymentError => e
     # there was an issue in processing charge, undeduct all already deducted inventory
     deducted_inventory.each { |li| GravityService.undeduct_inventory(li) }
-    e.transaction.update_attributes! order: @order if e.transaction.present?
+    e.transaction.update! order: @order if e.transaction.present?
     Rails.logger.error("Could not submit order #{@order.id}: #{e.message}")
     raise e
   end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -66,8 +66,8 @@ class OrderSubmitService
       merchant_account: @merchant_account,
       seller_amount: @order.seller_total_cents,
       currency_code: @order.currency_code,
-      metadata: {},
-      description: ''
+      metadata: charge_metadata,
+      description: charge_description
     }
   end
 
@@ -88,5 +88,20 @@ class OrderSubmitService
   def calculate_transaction_fee
     # This is based on Stripe US fee, it will be different for other countries
     (Money.new(@order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
+  end
+
+  def charge_description
+    "#{(@partner[:name] || '').parameterize[0...12].upcase} via Artsy"
+  end
+
+  def charge_metadata
+    {
+      exchange_order_id: @order.id,
+      buyer_id: @order.buyer_id,
+      buyer_type: @order.buyer_type,
+      seller_id: @order.seller_id,
+      seller_type: @order.seller_type,
+      type: 'bn-mo'
+    }
   end
 end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -10,7 +10,7 @@ class OrderSubmitService
     @credit_card = nil
     @merchant_account = nil
     @partner = nil
-    @charge = nil
+    @transaction = nil
   end
 
   def process!
@@ -24,8 +24,7 @@ class OrderSubmitService
         GravityService.deduct_inventory(li)
         deducted_inventory << li
       end
-      @charge = PaymentService.authorize_charge(construct_charge_params)
-      @order.update!(external_charge_id: @charge.id)
+      @transaction = PaymentService.authorize_charge(construct_charge_params)
     end
     post_process!
     @order
@@ -36,7 +35,7 @@ class OrderSubmitService
   rescue Errors::PaymentError => e
     # there was an issue in processing charge, undeduct all already deducted inventory
     deducted_inventory.each { |li| GravityService.undeduct_inventory(li) }
-    TransactionService.create!(@order, e.body)
+    e.transaction.update_attributes! order: @order if e.transaction.present?
     Rails.logger.error("Could not submit order #{@order.id}: #{e.message}")
     raise e
   end
@@ -54,32 +53,21 @@ class OrderSubmitService
   end
 
   def post_process!
-    TransactionService.create!(@order, construct_transaction_success(@charge))
+    @order.update!(external_charge_id: @transaction.external_id)
+    @order.transactions << @transaction
     PostNotificationJob.perform_later(@order.id, Order::SUBMITTED, @by)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
   end
 
-  def construct_transaction_success(charge)
-    {
-      external_id: charge.id,
-      source_id: charge.source,
-      destination_id: charge.destination,
-      amount_cents: charge.amount,
-      failure_code: charge.failure_code,
-      failure_message: charge.failure_message,
-      transaction_type: charge.transaction_type,
-      status: Transaction::SUCCESS
-    }
-  end
-
   def construct_charge_params
     {
-      source_id: @credit_card[:external_id],
-      customer_id: @credit_card[:customer_account][:external_id],
-      amount: @order.buyer_total_cents,
-      destination_id: @merchant_account[:external_id],
-      destination_amount: @order.seller_total_cents,
-      currency_code: @order.currency_code
+      credit_card: @credit_card,
+      buyer_amount: @order.buyer_total_cents,
+      merchant_account: @merchant_account,
+      seller_amount: @order.seller_total_cents,
+      currency_code: @order.currency_code,
+      metadata: {},
+      description: ''
     }
   end
 

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -1,64 +1,52 @@
 module PaymentService
-  def self.authorize_charge(source_id:, customer_id:, destination_id:, destination_amount:, amount:, currency_code:)
+  def self.authorize_charge(credit_card:, buyer_amount:, seller_amount:, merchant_account:, currency_code:, description:, metadata: {})
     charge = Stripe::Charge.create(
-      amount: amount,
+      amount: buyer_amount,
       currency: currency_code,
-      description: 'Artsy',
-      source: source_id,
-      customer: customer_id,
+      description: description,
+      source: credit_card[:external_id],
+      customer: credit_card[:customer_account][:external_id],
       destination: {
-        account: destination_id,
-        amount: destination_amount
+        account: merchant_account[:external_id],
+        amount: seller_amount
       },
+      metadata: metadata,
       capture: false
     )
-    charge.transaction_type = Transaction::HOLD
-    charge
+    Transaction.new(external_id: charge.id, source_id: charge.source, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::HOLD, status: Transaction::SUCCESS)
   rescue Stripe::StripeError => e
-    body = e.json_body[:error]
-    failed_charge = {
-      amount: amount,
-      external_id: body[:charge],
-      source_id: source_id,
-      destination_id: destination_id,
-      failure_code: body[:code],
-      failure_message: body[:message],
-      transaction_type: Transaction::HOLD,
-      status: Transaction::FAILURE
-    }
-    raise Errors::PaymentError.new(e.message, failed_charge)
+    transaction = generate_transaction_from_exception(e, Transaction::HOLD, credit_card, merchant_account, buyer_amount)
+    raise Errors::PaymentError.new(e.message, transaction)
   end
 
   def self.capture_charge(charge_id)
     charge = Stripe::Charge.retrieve(charge_id)
     charge.capture
-    charge.transaction_type = Transaction::CAPTURE
-    charge
+    Transaction.new(external_id: charge.id, source_id: charge.source, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
   rescue Stripe::StripeError => e
-    body = e.json_body[:error]
-    failed_charge = {
-      external_id: charge_id,
-      failure_code: body[:code],
-      failure_message: body[:message],
-      transaction_type: Transaction::CAPTURE,
-      status: Transaction::FAILURE
-    }
-    raise Errors::PaymentError.new(e.message, failed_charge)
+    transaction = generate_transaction_from_exception(e, Transaction::CAPTURE, credit_card: credit_card, merchant_account: merchant_account, buyer_amount: buyer_amount)
+    raise Errors::PaymentError.new(e.message, transaction)
   end
 
   def self.refund_charge(charge_id)
     refund = Stripe::Refund.create(charge: charge_id)
-    refund.transaction_type = Transaction::REFUND
-    refund
+    Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
   rescue Stripe::StripeError => e
+    transaction = generate_transaction_from_exception(e, Transaction::REFUND, charge_id: charge_id)
+    raise Errors::PaymentError.new(e.message, transaction)
+  end
+
+  def self.generate_transaction_from_exception(e, type, credit_card:nil, merchant_account:nil, buyer_amount:nil, charge_id: nil)
     body = e.json_body[:error]
-    failed_refund = {
-      external_id: charge_id,
+    transaction = Transaction.new(
+      external_id: charge_id || body[:charge],
+      source_id: (credit_card.present? ? credit_card[:external_id] : nil ),
+      destination_id: (merchant_account.present? ? merchant_account[:external_id] : nil),
+      amount_cents: buyer_amount,
       failure_code: body[:code],
       failure_message: body[:message],
-      transaction_type: Transaction::REFUND,
+      transaction_type: type,
       status: Transaction::FAILURE
-    }
-    raise Errors::PaymentError.new(e.message, failed_refund)
+    )
   end
 end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -38,8 +38,10 @@ describe OrderService, type: :services do
       before do
         artwork_inventory_undeduct_request
         edition_set_inventory_undeduct_request
-        StripeMock.prepare_card_error(:card_declined, :new_refund)
-        expect { OrderService.reject!(order, user_id) }.to raise_error(Errors::PaymentError)
+        allow(Stripe::Refund).to receive(:create)
+          .with(hash_including(charge: captured_charge.id))
+          .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: {error: { code: 'something', message: 'refund failed' }}))
+        expect { OrderService.reject!(order, user_id) }.to raise_error(Errors::PaymentError).and change(order.transactions, :count).by(1)
       end
       it 'raises a PaymentError and records the transaction' do
         expect(order.transactions.last.external_id).to eq captured_charge.id

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -40,7 +40,7 @@ describe OrderService, type: :services do
         edition_set_inventory_undeduct_request
         allow(Stripe::Refund).to receive(:create)
           .with(hash_including(charge: captured_charge.id))
-          .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: {error: { code: 'something', message: 'refund failed' }}))
+          .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
         expect { OrderService.reject!(order, user_id) }.to raise_error(Errors::PaymentError).and change(order.transactions, :count).by(1)
       end
       it 'raises a PaymentError and records the transaction' do

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -126,10 +126,9 @@ describe OrderSubmitService, type: :services do
         it 'calls stripe with expected params' do
           expect(Stripe::Charge).to receive(:create).with(
             amount: 10000_00,
-            currency: 'usd',
             source: stripe_customer.default_source,
+            currency: 'usd',
             customer: stripe_customer.id,
-            description: 'Artsy',
             destination: {
               account: 'ma-1',
               amount: 1709_70

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -129,12 +129,19 @@ describe OrderSubmitService, type: :services do
             source: stripe_customer.default_source,
             currency: 'usd',
             customer: stripe_customer.id,
+            metadata: {
+              exchange_order_id: order.id,
+              buyer_id: order.buyer_id,
+              buyer_type: 'user',
+              seller_id: 'partner-1',
+              seller_type: 'partner',
+              type: 'bn-mo'
+            },
             destination: {
               account: 'ma-1',
               amount: 1709_70
             },
-            description: '',
-            metadata: {},
+            description: 'INVOICING-DE via Artsy',
             capture: false
           ).and_return(captured_charge)
           artwork_inventory_deduct_request

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -134,6 +134,8 @@ describe OrderSubmitService, type: :services do
               account: 'ma-1',
               amount: 1709_70
             },
+            description: '',
+            metadata: {},
             capture: false
           ).and_return(captured_charge)
           artwork_inventory_deduct_request

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -13,7 +13,7 @@ describe PaymentService, type: :services do
   describe '#authorize_charge' do
     it "authorizes a charge on the user's credit card" do
       params = {
-        source_id: stripe_customer.default_source,
+        credit_card: stripe_customer.default_source,
         customer_id: stripe_customer.id,
         destination_id: destination_id,
         destination_amount: destination_amount,

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -5,90 +5,84 @@ require 'support/use_stripe_mock'
 describe PaymentService, type: :services do
   include_context 'use stripe mock'
 
-  let(:destination_id) { 'ma-1' }
   let(:currency_code) { 'usd' }
-  let(:charge_amount) { 22_22 }
-  let(:destination_amount) { 20_00 }
+  let(:buyer_amount) { 20_00 }
+  let(:seller_amount) { 10_00 }
+  let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+  let(:merchant_account) { { external_id: 'ma-1' } }
+  let(:params) do
+    {
+      buyer_amount: buyer_amount,
+      credit_card: credit_card,
+      currency_code: currency_code,
+      description: 'Gallery via Artsy',
+      merchant_account: merchant_account,
+      metadata: { this: 'is', a: 'test' },
+      seller_amount: seller_amount
+    }
+  end
 
   describe '#authorize_charge' do
     it "authorizes a charge on the user's credit card" do
-      params = {
-        credit_card: stripe_customer.default_source,
-        customer_id: stripe_customer.id,
-        destination_id: destination_id,
-        destination_amount: destination_amount,
-        currency_code: currency_code,
-        amount: charge_amount
-      }
-      charge = PaymentService.authorize_charge(params)
-      expect(charge.amount).to eq(charge_amount)
-      expect(charge.destination.account).to eq(destination_id)
-      expect(charge.destination.amount).to eq(20_00)
-      expect(charge.customer).to eq(stripe_customer.id)
-      expect(charge.source.id).to eq(stripe_customer.default_source)
-      expect(charge.currency).to eq(currency_code)
-      expect(charge.description).to eq('Artsy')
-      expect(charge.captured).to eq(false)
-      expect(charge.transaction_type).to eq Transaction::HOLD
+      transaction = PaymentService.authorize_charge(params)
+      expect(transaction.amount_cents).to eq(20_00)
+      expect(transaction.source_id).to eq(stripe_customer.default_source)
+      expect(transaction.status).to eq(Transaction::SUCCESS)
+      expect(transaction.transaction_type).to eq Transaction::HOLD
+      expect(transaction.failure_code).to be_nil
+      expect(transaction.failure_message).to be_nil
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:card_declined, :new_charge)
-      params = {
-        source_id: stripe_customer.default_source,
-        customer_id: stripe_customer.id,
-        destination_id: destination_id,
-        destination_amount: destination_amount,
-        currency_code: currency_code,
-        amount: charge_amount
-      }
       expect { PaymentService.authorize_charge(params) }.to(raise_error do |e|
         expect(e).to be_a Errors::PaymentError
         expect(e.message).not_to eq nil
-        expect(e.body[:amount]).to eq charge_amount
-        expect(e.body[:source_id]).to eq stripe_customer.default_source
-        expect(e.body[:destination_id]).to eq destination_id
-        expect(e.body[:failure_code]).not_to eq nil
-        expect(e.body[:failure_message]).not_to eq nil
-        expect(e.body[:transaction_type]).to eq Transaction::HOLD
+        expect(e.transaction.amount_cents).to eq buyer_amount
+        expect(e.transaction.source_id).to eq stripe_customer.default_source
+        expect(e.transaction.destination_id).to eq 'ma-1'
+        expect(e.transaction.failure_code).not_to eq nil
+        expect(e.transaction.failure_message).not_to eq nil
+        expect(e.transaction.transaction_type).to eq Transaction::HOLD
       end)
     end
   end
 
   describe '#capture_charge' do
     it 'captures a charge' do
-      captured_charge = PaymentService.capture_charge(uncaptured_charge.id)
-      expect(captured_charge.captured).to eq(true)
-      expect(captured_charge.transaction_type).to eq Transaction::CAPTURE
+      transaction = PaymentService.capture_charge(uncaptured_charge.id)
+      expect(transaction.amount_cents).to eq(uncaptured_charge.amount)
+      expect(transaction.transaction_type).to eq Transaction::CAPTURE
+      expect(transaction.status).to eq Transaction::SUCCESS
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:card_declined, :capture_charge)
       expect { PaymentService.capture_charge(uncaptured_charge.id) }.to(raise_error do |e|
         expect(e).to be_a Errors::PaymentError
         expect(e.message).not_to eq nil
-        expect(e.body[:external_id]).to eq uncaptured_charge.id
-        expect(e.body[:failure_code]).not_to eq nil
-        expect(e.body[:failure_message]).not_to eq nil
-        expect(e.body[:transaction_type]).to eq Transaction::CAPTURE
+        expect(e.transaction.external_id).to eq uncaptured_charge.id
+        expect(e.transaction.failure_code).not_to eq nil
+        expect(e.transaction.failure_message).not_to eq nil
+        expect(e.transaction.transaction_type).to eq Transaction::CAPTURE
       end)
     end
   end
 
   describe '#refund_charge' do
     it 'refunds a charge for the full amount' do
-      refund = PaymentService.refund_charge(captured_charge.id)
-      expect(refund.amount).to eq captured_charge.amount
-      expect(refund.charge).to eq captured_charge.id
-      expect(refund.transaction_type).to eq Transaction::REFUND
+      transaction = PaymentService.refund_charge(captured_charge.id)
+      expect(transaction.external_id).to match(/test_re/i)
+      expect(transaction.transaction_type).to eq Transaction::REFUND
+      expect(transaction.status).to eq Transaction::SUCCESS
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:processing_error, :new_refund)
       expect { PaymentService.refund_charge(captured_charge.id) }.to(raise_error do |e|
         expect(e).to be_a Errors::PaymentError
         expect(e.message).not_to eq nil
-        expect(e.body[:external_id]).to eq captured_charge.id
-        expect(e.body[:failure_code]).not_to eq nil
-        expect(e.body[:failure_message]).not_to eq nil
-        expect(e.body[:transaction_type]).to eq Transaction::REFUND
+        expect(e.transaction.external_id).to eq captured_charge.id
+        expect(e.transaction.failure_code).not_to eq nil
+        expect(e.transaction.failure_message).not_to eq nil
+        expect(e.transaction.transaction_type).to eq Transaction::REFUND
       end)
     end
   end

--- a/spec/support/use_stripe_mock.rb
+++ b/spec/support/use_stripe_mock.rb
@@ -19,12 +19,17 @@ RSpec.shared_context 'use stripe mock' do
       capture: false
     )
   end
+  let(:buyer_amount) { 22_222 }
+  let(:seller_amount) { 10_000 }
   let(:captured_charge) do
     Stripe::Charge.create(
-      amount: 22_222,
+      amount: buyer_amount,
       currency: 'usd',
       source: stripe_helper.generate_card_token,
-      destination: 'ma-1',
+      destination: {
+        account: 'ma-1',
+        amount: seller_amount
+      },
       capture: true
     )
   end


### PR DESCRIPTION
# What has changed here?
Main change here was changing `PaymentService` to instead of returning hash of charge results back and have the caller `OrderService` or `OrderSubmitService` translate Stripe `charge` to `Transaction`.

In case of failure, we raise exception and we attach a failed transaction.

The caller of `PaymentService` then gets that transactions and attaches it to the `order`.

Also in this PR added `metadata` and `description` to the Stripe charge call.